### PR TITLE
Moving babel-polyfill into devDependencies as it's adding bloat

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "babel-cli": "^6.7.7",
     "babel-core": "^6.7.7",
     "babel-eslint": "^6.0.4",
+    "babel-polyfill": "^6.7.4",
     "babel-preset-es2015": "^6.6.0",
     "babel-preset-stage-0": "^6.5.0",
     "eslint": "^2.8.0",
@@ -33,7 +34,6 @@
   },
   "license": "MIT",
   "dependencies": {
-    "babel-polyfill": "^6.7.4",
     "graphql": "^0.9.0",
     "lodash": "^4.11.1"
   }


### PR DESCRIPTION
*TL;DR* This leaks through to downstream builds/packages, so moving it out. 

In my use-case: `jest` sees that there's a `babel-polyfill` package in `node_modules`, and uses it. In a CI environment this hits a particular memory issue wherein our box runs out of available heap for tests to run, and tests die.

I think `babel-polyfill`'s inclusion into `dependencies` _may_ be accidental, however it should really only be included in dev and not downstream packages.