### PR TITLE
Add OperationsMustHaveNames lint rule

### DIFF
--- a/src/rules.js
+++ b/src/rules.js
@@ -1,0 +1,14 @@
+import { GraphQLError } from 'graphql';
+
+export function OperationsMustHaveNames(context) {
+  return {
+    OperationDefinition(node) {
+      if (!node.name) {
+        context.reportError(
+          new GraphQLError("All operations must be named", [ node ])
+        );
+      }
+    },
+  };
+}
+

--- a/test/makeRule.js
+++ b/test/makeRule.js
@@ -839,13 +839,11 @@ const namedOperationsValidatorCases = {
   }
 
   // Validate the named-operations rule
-  for (const [validatorName, {pass, fail, errors}] of Object.entries(namedOperationsValidatorCases)) {
-    options = [{
-      schemaJson, tagName: 'gql',
-    }];
-    ruleTester.run(`enabled ${validatorName} validator`, rules['named-operations'], {
-      valid:  [namedOperationsValidatorCases[validatorName]].map(({pass: code}) => ({options, parserOptions, code})),
-      invalid:  [namedOperationsValidatorCases[validatorName]].map(({fail: code, errors}) => ({options, parserOptions, code, errors})),
-    });
-  }
+  options = [{
+    schemaJson, tagName: 'gql',
+  }];
+  ruleTester.run('testing named-operations rule', rules['named-operations'], {
+    valid: Object.values(namedOperationsValidatorCases).map(({pass: code}) => ({options, parserOptions, code})),
+    invalid: Object.values(namedOperationsValidatorCases).map(({fail: code, errors}) => ({options, parserOptions, code, errors})),
+  });
 }

--- a/test/makeRule.js
+++ b/test/makeRule.js
@@ -782,6 +782,17 @@ const validatorCases = {
   },
 };
 
+const namedOperationsValidatorCases = {
+  'OperationsMustHaveNames': {
+    pass: 'const x = gql`query Test { sum(a: 1, b: 2) }`',
+    fail: 'const x = gql`query { sum(a: 1, b: 2) }`',
+    errors: [{
+      message: 'All operations must be named',
+      type: 'TaggedTemplateExpression',
+    }],
+  },
+};
+
 {
   let options = [{
     schemaJson, tagName: 'gql',
@@ -824,6 +835,17 @@ const validatorCases = {
         otherValidators.map(({fail: code}) => code),
       ).map(code => ({options, parserOptions, code})),
       invalid: [{options, parserOptions, errors, code: fail}],
+    });
+  }
+
+  // Validate the named-operations rule
+  for (const [validatorName, {pass, fail, errors}] of Object.entries(namedOperationsValidatorCases)) {
+    options = [{
+      schemaJson, tagName: 'gql',
+    }];
+    ruleTester.run(`enabled ${validatorName} validator`, rules['named-operations'], {
+      valid:  [namedOperationsValidatorCases[validatorName]].map(({pass: code}) => ({options, parserOptions, code})),
+      invalid:  [namedOperationsValidatorCases[validatorName]].map(({fail: code, errors}) => ({options, parserOptions, code, errors})),
     });
   }
 }


### PR DESCRIPTION
Adds a lint rule that enforces all operations are named. See https://github.com/apollographql/eslint-plugin-graphql/issues/42 and https://apollographql.slack.com/archives/eslint-plugin-graphql/p1488999103000014.

This adds it as a separate rule: `graphql/named-operations` so that it's easier for folks to configure it on or off / warn vs error. Did a little restructuring to be more DRY

TODO:

- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests pass
- [ ] Update CHANGELOG.md with your change
- [ ] If this was a change that affects the external API, update the README
