### PR TITLE
Lint for required fields [WIP]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### vNEXT
 
 - Updated `graphql` dependency to resolve test failures ([wording change](https://github.com/graphql/graphql-js/commit/ba401e154461bca5323ca9121c6dacaee10ebe88), no API change) [jnwng](https://github.com/jnwng)
+- Add lint rule to enforce that required fields are specified. [rgoldfinger](https://github.com/rgoldfinger) in [#47](https://github.com/apollographql/eslint-plugin-graphql/pull/50)
 
 ### v0.7.0
 - Add lint rule to enforce that operations have names [gauravmk](https://github.com/gauravmk) in [#47](https://github.com/apollographql/eslint-plugin-graphql/pull/47)

--- a/README.md
+++ b/README.md
@@ -263,7 +263,7 @@ query {
 }
 ```
 
-The rule is defined as `graphql/named-operations` and requires a `schema` and optional `tagName`
+The rule is defined as `graphql/named-operations` and requires a `schema` and optional `tagName`.
 
 ```js
 // In a file called .eslintrc.js
@@ -277,6 +277,89 @@ module.exports = {
     "graphql/named-operations": ['warning' {
       schemaJson: require('./schema.json'),
     }],
+  },
+  plugins: [
+    'graphql'
+  ]
+}
+```
+### Required Fields Validation Rule
+
+The Required Fields rule validates that any specified required field is part of the query, but only if that field is available in schema. This is useful to ensure that query results are cached properly in the client.
+
+**Pass**
+```
+// 'uuid' required
+
+schema {
+  query {
+    viewer {
+      uuid
+      name
+    }
+  }
+}
+
+query ViewerName {
+  viewer {
+    name
+    uuid
+  }
+}
+```
+
+**Pass**
+```
+// 'uuid' required
+
+schema {
+  query {
+    viewer {
+      name
+    }
+  }
+}
+
+query ViewerName {
+  viewer {
+    name
+  }
+}
+```
+
+**Fail**
+```
+// 'uuid' required
+
+schema {
+  query {
+    viewer {
+      uuid
+      name
+    }
+  }
+}
+
+query ViewerName {
+  viewer {
+    name
+  }
+}
+```
+
+The rule is defined as `graphql/required-fields` and requires a `schema` and `requiredFields`, with an optional `tagName`.
+
+```js
+// In a file called .eslintrc.js
+module.exports = {
+  rules: {
+    'graphql/required-fields': [
+      'error',
+      {
+        schemaJsonFilepath: require('./schema.json'),
+        requiredFields: ['uuid'],
+      },
+    ],
   },
   plugins: [
     'graphql'

--- a/src/index.js
+++ b/src/index.js
@@ -145,7 +145,46 @@ const rules = {
         ...optionGroup,
       }));;
     },
-  }
+  },
+  'required-fields': {
+    meta: {
+      schema: {
+        type: 'array',
+        minLength: 1,
+        items: {
+          additionalProperties: false,
+          properties: {
+            ...defaultRuleProperties,
+            requiredFields: {
+              type: 'array',
+              items: {
+                type: 'string',
+              },
+            },
+          },
+          oneOf: [
+            {
+              required: ['schemaJson'],
+              not: { required: ['schemaJsonFilepath'] },
+            },
+            {
+              required: ['schemaJsonFilepath'],
+              not: { required: ['schemaJson'] },
+            },
+          ],
+        },
+      },
+    },
+    create: context => {
+      return createRule(context, optionGroup =>
+        parseOptions({
+          validators: ['RequiredFields'],
+          options: { requiredFields: optionGroup.requiredFields },
+          ...optionGroup,
+        })
+      );
+    },
+  },
 };
 
 function parseOptions(optionGroup) {

--- a/src/index.js
+++ b/src/index.js
@@ -59,11 +59,12 @@ function createRule(context, optionParser) {
   const tagRules = [];
   for (const optionGroup of context.options) {
     const {schema, env, tagName, validators} = optionParser(optionGroup);
+    const boundValidators = validators.map(v => (ctx) => v(ctx, optionGroup));
     if (tagNames.has(tagName)) {
       throw new Error('Multiple options for GraphQL tag ' + tagName);
     }
     tagNames.add(tagName);
-    tagRules.push({schema, env, tagName, validators});
+    tagRules.push({schema, env, tagName, validators: boundValidators});
   }
   return {
     TaggedTemplateExpression(node) {

--- a/src/rules.js
+++ b/src/rules.js
@@ -20,7 +20,7 @@ export function RequiredFields(context, options) {
       requiredFields.forEach(field => {
         if (def.type && def.type._fields && def.type._fields[field]) {
           const fieldWasRequested = !!node.selectionSet.selections.find(
-            n => n.name.value === field
+            n => (n.name.value === field || n.kind === 'FragmentSpread')
           );
           if (!fieldWasRequested) {
             context.reportError(

--- a/src/rules.js
+++ b/src/rules.js
@@ -12,3 +12,23 @@ export function OperationsMustHaveNames(context) {
   };
 }
 
+export function RequiredFields(context) {
+  return {
+    Field(node, _ctx, _schema, _env, _validators, options) {
+      const def = context.getFieldDef();
+      const { requiredFields } = options;
+      requiredFields.forEach(field => {
+        if (def.type && def.type._fields && def.type._fields[field]) {
+          const fieldWasRequested = !!node.selectionSet.selections.find(
+            n => n.name.value === field
+          );
+          if (!fieldWasRequested) {
+            context.reportError(
+              new GraphQLError(`'${field}' field required on '${node.name.value}'`, [node])
+            );
+          }
+        }
+      });
+    },
+  };
+}

--- a/src/rules.js
+++ b/src/rules.js
@@ -18,9 +18,17 @@ export function RequiredFields(context, options) {
       const def = context.getFieldDef();
       const { requiredFields } = options;
       requiredFields.forEach(field => {
-        console.log('def', def);
-        if (def.type && def.type._fields && def.type._fields[field]) {
+        const fieldAvaliableOnType = def.type && def.type._fields && def.type._fields[field];
 
+        function recursivelyCheckOnType(ofType, field) {
+          return (ofType._fields && ofType._fields[field]) || (ofType.ofType && recursivelyCheckOnType(ofType.ofType, field));
+        }
+
+        let fieldAvaliableOnOfType = false;
+        if (def.type && def.type.ofType) {
+          fieldAvaliableOnOfType = recursivelyCheckOnType(def.type.ofType, field);
+        }
+        if (fieldAvaliableOnType || fieldAvaliableOnOfType) {
           const fieldWasRequested = !!node.selectionSet.selections.find(
             n => (n.name.value === field || n.kind === 'FragmentSpread')
           );

--- a/src/rules.js
+++ b/src/rules.js
@@ -18,7 +18,9 @@ export function RequiredFields(context, options) {
       const def = context.getFieldDef();
       const { requiredFields } = options;
       requiredFields.forEach(field => {
+        console.log('def', def);
         if (def.type && def.type._fields && def.type._fields[field]) {
+
           const fieldWasRequested = !!node.selectionSet.selections.find(
             n => (n.name.value === field || n.kind === 'FragmentSpread')
           );

--- a/src/rules.js
+++ b/src/rules.js
@@ -12,9 +12,9 @@ export function OperationsMustHaveNames(context) {
   };
 }
 
-export function RequiredFields(context) {
+export function RequiredFields(context, options) {
   return {
-    Field(node, _ctx, _schema, _env, _validators, options) {
+    Field(node) {
       const def = context.getFieldDef();
       const { requiredFields } = options;
       requiredFields.forEach(field => {

--- a/test/makeRule.js
+++ b/test/makeRule.js
@@ -793,6 +793,17 @@ const namedOperationsValidatorCases = {
   },
 };
 
+const requiredFieldsTestCases = {
+  'RequiredFields': {
+    pass: 'const x = gql`query Test { stories { id comments { text } } }`',
+    fail: 'const x = gql`query Test { stories { comments { text } } }`',
+    errors: [{
+      message: 'All operations must be named',
+      type: 'TaggedTemplateExpression',
+    }],
+  },
+};
+
 {
   let options = [{
     schemaJson, tagName: 'gql',
@@ -845,5 +856,16 @@ const namedOperationsValidatorCases = {
   ruleTester.run('testing named-operations rule', rules['named-operations'], {
     valid: Object.values(namedOperationsValidatorCases).map(({pass: code}) => ({options, parserOptions, code})),
     invalid: Object.values(namedOperationsValidatorCases).map(({fail: code, errors}) => ({options, parserOptions, code, errors})),
+  });
+
+  // Validate the required-fields rule
+  options = [{
+    schemaJson,
+    tagName: 'gql',
+    requiredFields: ['id'],
+  }];
+  ruleTester.run('testing required-fields rule', rules['required-fields'], {
+    valid: Object.values(requiredFieldsTestCases).map(({pass: code}) => ({options, parserOptions, code})),
+    invalid: Object.values(requiredFieldsTestCases).map(({fail: code, errors}) => ({options, parserOptions, code, errors})),
   });
 }

--- a/test/makeRule.js
+++ b/test/makeRule.js
@@ -794,14 +794,19 @@ const namedOperationsValidatorCases = {
 };
 
 const requiredFieldsTestCases = {
-  'RequiredFields': {
-    pass: 'const x = gql`query Test { stories { id comments { text } } }`',
-    fail: 'const x = gql`query Test { stories { comments { text } } }`',
-    errors: [{
-      message: 'All operations must be named',
-      type: 'TaggedTemplateExpression',
-    }],
-  },
+  pass: [
+    'const x = gql`query { allFilms { films { title } } }`',
+    'const x = gql`query { stories { id comments { text } } }`'
+  ],
+  fail: [
+    {
+      code: 'const x = gql`query { stories { comments { text } } }`',
+      errors: [{
+        message: 'All operations must be named',
+        type: 'TaggedTemplateExpression',
+      }],
+    },
+  ],
 };
 
 {
@@ -865,7 +870,7 @@ const requiredFieldsTestCases = {
     requiredFields: ['id'],
   }];
   ruleTester.run('testing required-fields rule', rules['required-fields'], {
-    valid: Object.values(requiredFieldsTestCases).map(({pass: code}) => ({options, parserOptions, code})),
-    invalid: Object.values(requiredFieldsTestCases).map(({fail: code, errors}) => ({options, parserOptions, code, errors})),
+    valid: requiredFieldsTestCases.pass.map((code) => ({options, parserOptions, code})),
+    invalid: requiredFieldsTestCases.fail.map(({code, errors}) => ({options, parserOptions, code, errors})),
   });
 }

--- a/test/makeRule.js
+++ b/test/makeRule.js
@@ -802,7 +802,14 @@ const requiredFieldsTestCases = {
     {
       code: 'const x = gql`query { stories { comments { text } } }`',
       errors: [{
-        message: 'All operations must be named',
+        message: `'id' field required on 'stories'`,
+        type: 'TaggedTemplateExpression',
+      }],
+    },
+    {
+      code: 'const x = gql`query { greetings { hello } }`',
+      errors: [{
+        message: `'id' field required on 'greetings'`,
         type: 'TaggedTemplateExpression',
       }],
     },

--- a/test/schema.graphql
+++ b/test/schema.graphql
@@ -29,6 +29,7 @@ type RootQuery {
   allFilms: AllFilmsObj
   sum(a: Int!, b: Int!): Int!
   greetings: Greetings
+  stories: [Story!]!
 }
 
 type AllFilmsObj {

--- a/test/schema.graphql
+++ b/test/schema.graphql
@@ -43,6 +43,7 @@ type Film {
 }
 
 type Greetings {
+  id: ID
   hello: String
 }
 


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on eslint-plugin-graphql!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

We have a need to validate that the queries include a `uuid` field, since that's how we cache things client side. I thought I'd try to make this more generic, as a 'required field' lint rule that errors if the field is 1) present in the schema and 2) not requested in this query.

Is this something that you think is worth including in this package? 

Can you offer any guidance on how to pass the rule's options to the rule itself? The rule is invoked within graphql's `validate`, so I'm not seeing a clear way to do this. 

TODO:

- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests pass
- [x] Update CHANGELOG.md with your change
- [x] If this was a change that affects the external API, update the README
