### PR TITLE
In 'literal' env, don't validate that fragments exist or are used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ### vNEXT
 
+### v0.8.2
+- Remove `KnownFragmentNames` and `UnusedFragment` from default rules in `literal` env. [Justin Schulz](https://github.com/PepperTeasdale) in [#70](https://github.com/apollographql/eslint-plugin-graphql/pull/70)
+
 ### v0.8.1
 - Fix `graphql/required-fields` throwing on non-existent field reference [Benjie](https://github.com/benjie) in [#65](https://github.com/apollographql/eslint-plugin-graphql/pull/65)
 

--- a/src/index.js
+++ b/src/index.js
@@ -36,6 +36,10 @@ const envGraphQLValidatorNames = {
     'ProvidedNonNullArguments',
     'ScalarLeafs',
   ),
+  literal: without(allGraphQLValidatorNames,
+    'KnownFragmentNames',
+    'NoUnusedFragments',
+  ),
 };
 
 const internalTag = 'ESLintPluginGraphQLFile';


### PR DESCRIPTION
Literal .graphql file imports are not properly reconciled, and the KnownFragmentNames and NoUnusedFragment rules will fail. This removes them from the default rules for the literal env. This is a band-aid toward #69 

Note: Did not see any tests for the default rules used by envs (tests for `literal` generally). Happy to provide test coverage, but please advise on what kind of test you'd like to see for this :)

TODO:

- [ ] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests pass
- [x] Update CHANGELOG.md with your change
- [x] If this was a change that affects the external API, update the README
