### PR TITLE
Remove use of Array.prototype.includes to support older runtimes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change log
 
 ### vNEXT
+- Fix template env for older runtimes (eg. node 5 and earlier) [Justin Schulz](https://github.com/PepperTeasdale) in [#73](https://github.com/apollographql/eslint-plugin-graphql/pull/73)
 
 ### v0.8.2
 - Remove `KnownFragmentNames` and `UnusedFragment` from default rules in `literal` env. [Justin Schulz](https://github.com/PepperTeasdale) in [#70](https://github.com/apollographql/eslint-plugin-graphql/pull/70)

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "babel-cli": "^6.7.7",
     "babel-core": "^6.7.7",
     "babel-eslint": "^7.1.1",
-    "babel-polyfill": "^6.7.4",
+    "babel-plugin-transform-runtime": "^6.23.0",
     "babel-preset-es2015": "^6.6.0",
     "babel-preset-stage-0": "^6.5.0",
     "eslint": "^3.17.0",

--- a/src/index.js
+++ b/src/index.js
@@ -12,6 +12,7 @@ import {
   last,
   reduce,
   without,
+  includes,
 } from 'lodash';
 
 import * as customRules from './rules';
@@ -421,7 +422,7 @@ const gqlProcessor = {
   postprocess: function(messages) {
     // only report graphql-errors
     return flatten(messages).filter((message) => {
-      return keys(rules).map((key) => `graphql/${key}`).includes(message.ruleId);
+      return includes(keys(rules).map((key) => `graphql/${key}`), message.ruleId);
     })
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -1,7 +1,9 @@
 // This file cannot be written with ECMAScript 2015 because it has to load
 // the Babel require hook to enable ECMAScript 2015 features!
 require('babel-core/register');
-require('babel-polyfill');
+require('babel-core').transform('code', {
+  plugins: ['transform-runtime']
+});
 
 // The tests, however, can and should be written with ECMAScript 2015.
 require('./makeRule');

--- a/test/makeRule.js
+++ b/test/makeRule.js
@@ -2,6 +2,11 @@ import { rules } from '../src';
 import { RuleTester } from 'eslint';
 import schemaJson from './schema.json';
 import path from 'path';
+import {
+  includes,
+  values,
+  entries,
+} from 'lodash';
 
 const schemaJsonFilepath = path.resolve(__dirname, './schema.json');
 const secondSchemaJsonFilepath = path.resolve(__dirname, './second-schema.json');
@@ -823,8 +828,8 @@ const requiredFieldsTestCases = {
     validators: 'all',
   }];
   ruleTester.run('enabled all validators', rule, {
-    valid: Object.values(validatorCases).map(({pass: code}) => ({options, parserOptions, code})),
-    invalid: Object.values(validatorCases).map(({fail: code, errors}) => ({options, parserOptions, code, errors})),
+    valid: values(validatorCases).map(({pass: code}) => ({options, parserOptions, code})),
+    invalid: values(validatorCases).map(({fail: code, errors}) => ({options, parserOptions, code, errors})),
   });
 
   options = [{
@@ -833,8 +838,8 @@ const requiredFieldsTestCases = {
   }];
   ruleTester.run('disabled all validators', rule, {
     valid: [].concat(
-      Object.values(validatorCases).map(({pass: code}) => code),
-      Object.values(validatorCases).map(({fail: code}) => code),
+      values(validatorCases).map(({pass: code}) => code),
+      values(validatorCases).map(({fail: code}) => code),
     ).map(code => ({options, parserOptions, code})),
     invalid: [],
   });
@@ -843,19 +848,19 @@ const requiredFieldsTestCases = {
   // that can fail. (Excluding test cases that include this validation rule as
   // 'alsoBreaks'…sometimes it's hard to make a test that fails exactly one
   // validator).
-  for (const [validatorName, {pass, fail, errors}] of Object.entries(validatorCases)) {
+  for (const [validatorName, {pass, fail, errors}] of entries(validatorCases)) {
     options = [{
       schemaJson, tagName: 'gql',
       validators: [validatorName],
     }];
     const otherValidators = (
-      Object.entries(validatorCases)
-        .filter(([otherValidatorName, {alsoBreaks}]) => otherValidatorName !== validatorName && !(alsoBreaks || []).includes(validatorName))
+      entries(validatorCases)
+        .filter(([otherValidatorName, {alsoBreaks}]) => otherValidatorName !== validatorName && !includes((alsoBreaks || []), validatorName))
         .map(([name, testCases]) => testCases)
     );
     ruleTester.run(`enabled only ${validatorName} validator`, rule, {
       valid: [].concat(
-        Object.values(validatorCases).map(({pass: code}) => code),
+        values(validatorCases).map(({pass: code}) => code),
         otherValidators.map(({fail: code}) => code),
       ).map(code => ({options, parserOptions, code})),
       invalid: [{options, parserOptions, errors, code: fail}],
@@ -867,8 +872,8 @@ const requiredFieldsTestCases = {
     schemaJson, tagName: 'gql',
   }];
   ruleTester.run('testing named-operations rule', rules['named-operations'], {
-    valid: Object.values(namedOperationsValidatorCases).map(({pass: code}) => ({options, parserOptions, code})),
-    invalid: Object.values(namedOperationsValidatorCases).map(({fail: code, errors}) => ({options, parserOptions, code, errors})),
+    valid: values(namedOperationsValidatorCases).map(({pass: code}) => ({options, parserOptions, code})),
+    invalid: values(namedOperationsValidatorCases).map(({fail: code, errors}) => ({options, parserOptions, code, errors})),
   });
 
   // Validate the required-fields rule

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,9 +2,9 @@
 # yarn lockfile v1
 
 
-"@types/graphql@^0.8.5":
-  version "0.8.6"
-  resolved "https://registry.yarnpkg.com/@types/graphql/-/graphql-0.8.6.tgz#b34fb880493ba835b0c067024ee70130d6f9bb68"
+"@types/graphql@^0.9.0":
+  version "0.9.1"
+  resolved "https://registry.yarnpkg.com/@types/graphql/-/graphql-0.9.1.tgz#b04ebe84bc997cc60dbea2ed4d0d4342c737f99d"
 
 abbrev@1:
   version "1.1.0"
@@ -633,6 +633,12 @@ babel-plugin-transform-regenerator@^6.24.1:
   dependencies:
     regenerator-transform "0.9.11"
 
+babel-plugin-transform-runtime@^6.23.0:
+  version "6.23.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-runtime/-/babel-plugin-transform-runtime-6.23.0.tgz#88490d446502ea9b8e7efb0fe09ec4d99479b1ee"
+  dependencies:
+    babel-runtime "^6.22.0"
+
 babel-plugin-transform-strict-mode@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz#d5faf7aa578a65bbe591cf5edae04a0c67020758"
@@ -640,7 +646,7 @@ babel-plugin-transform-strict-mode@^6.24.1:
     babel-runtime "^6.22.0"
     babel-types "^6.24.1"
 
-babel-polyfill@^6.23.0, babel-polyfill@^6.7.4:
+babel-polyfill@^6.23.0:
   version "6.23.0"
   resolved "https://registry.yarnpkg.com/babel-polyfill/-/babel-polyfill-6.23.0.tgz#8364ca62df8eafb830499f699177466c3b03499d"
   dependencies:
@@ -1356,19 +1362,19 @@ graceful-fs@^4.1.2, graceful-fs@^4.1.4:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/graceful-readlink/-/graceful-readlink-1.0.1.tgz#4cafad76bc62f02fa039b2f94e9a3dd3a391a725"
 
-graphql-tools@^0.10.1:
-  version "0.10.1"
-  resolved "https://registry.yarnpkg.com/graphql-tools/-/graphql-tools-0.10.1.tgz#274aa338d50b1c0b3ed6936eafd8ed3a19ed1828"
+graphql-tools@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/graphql-tools/-/graphql-tools-1.0.0.tgz#76b25e1dce0521b31d5566aac281b2f134bc49c8"
   dependencies:
     deprecated-decorator "^0.1.6"
     lodash "^4.3.0"
     uuid "^3.0.1"
   optionalDependencies:
-    "@types/graphql" "^0.8.5"
+    "@types/graphql" "^0.9.0"
 
-graphql@^0.9.5:
-  version "0.9.5"
-  resolved "https://registry.yarnpkg.com/graphql/-/graphql-0.9.5.tgz#efe588b98fe3ce036d7d55b4ad940daed56c4622"
+graphql@^0.9.6:
+  version "0.9.6"
+  resolved "https://registry.yarnpkg.com/graphql/-/graphql-0.9.6.tgz#514421e9d225c29dfc8fd305459abae58815ef2c"
   dependencies:
     iterall "^1.0.0"
 
@@ -1787,9 +1793,9 @@ mkdirp@0.5.1, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1:
   dependencies:
     minimist "0.0.8"
 
-mocha@^3.2.0:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/mocha/-/mocha-3.3.0.tgz#d29b7428d3f52c82e2e65df1ecb7064e1aabbfb5"
+mocha@^3.4.2:
+  version "3.4.2"
+  resolved "https://registry.yarnpkg.com/mocha/-/mocha-3.4.2.tgz#d0ef4d332126dbf18d0d640c9b382dd48be97594"
   dependencies:
     browser-stdout "1.3.0"
     commander "2.9.0"


### PR DESCRIPTION
Also removes `babel-polyfill` in favor of `transform-runtime` to surface these runtime-specific issues in testing.

@stubailo 👀  please

TODO:

- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests pass
- [x] Update CHANGELOG.md with your change
- [x] If this was a change that affects the external API, update the README

;)
