### PR TITLE
Add env option to required-fields rule config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 lib
 test/schema.json
 test/second-schema.json
+.vscode/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change log
 
 ### vNEXT
+- Add env config option for required-fields rule [Justin Schulz](https://github.com/PepperTeasdale) in [#75](https://github.com/apollographql/eslint-plugin-graphql/pull/75)
 
 ### v1.1.0
 - Add option to pass schema as string [Christopher Cliff](https://github.com/christophercliff) in [#78](https://github.com/apollographql/eslint-plugin-graphql/pull/78)

--- a/README.md
+++ b/README.md
@@ -234,12 +234,12 @@ The full list of available validators is:
   - `FragmentsOnCompositeTypes`
   - `KnownArgumentNames`
   - `KnownDirectives` (*disabled by default in `relay`*)
-  - `KnownFragmentNames` (*disabled by default in `apollo`, `lokka`, and `relay`*)
+  - `KnownFragmentNames` (*disabled by default in all envs*)
   - `KnownTypeNames`
   - `LoneAnonymousOperation`
   - `NoFragmentCycles`
   - `NoUndefinedVariables` (*disabled by default in `relay`*)
-  - `NoUnusedFragments` (*disabled by default in `apollo`, `lokka`, and `relay`*)
+  - `NoUnusedFragments` (*disabled by default in all envs*)
   - `NoUnusedVariables`
   - `OverlappingFieldsCanBeMerged`
   - `PossibleFragmentSpreads`
@@ -359,7 +359,7 @@ query ViewerName {
 }
 ```
 
-The rule is defined as `graphql/required-fields` and requires a `schema` and `requiredFields`, with an optional `tagName`.
+The rule is defined as `graphql/required-fields` and requires a `schema` and `requiredFields`, with an optional `tagName` and `env`.
 
 ```js
 // In a file called .eslintrc.js
@@ -368,7 +368,8 @@ module.exports = {
     'graphql/required-fields': [
       'error',
       {
-        schemaJsonFilepath: require('./schema.json'),
+        env: 'apollo',
+        schemaJsonFilepath: path.resolve(__dirname, './schema.json'),
         requiredFields: ['uuid'],
       },
     ],

--- a/src/index.js
+++ b/src/index.js
@@ -171,6 +171,14 @@ const rules = {
           additionalProperties: false,
           properties: {
             ...defaultRuleProperties,
+            env: {
+              enum: [
+                'lokka',
+                'relay',
+                'apollo',
+                'literal',
+              ],
+            },
             requiredFields: {
               type: 'array',
               items: {

--- a/src/index.js
+++ b/src/index.js
@@ -446,7 +446,6 @@ const gqlProcessor = {
     return [`${internalTag}\`${escaped}\``];
   },
   postprocess: function(messages) {
-    console.log('postprocess', messages)
     // only report graphql-errors
     return flatten(messages).filter((message) => {
       return includes(keys(rules).map((key) => `graphql/${key}`), message.ruleId);

--- a/src/index.js
+++ b/src/index.js
@@ -75,6 +75,7 @@ function createRule(context, optionParser) {
     tagNames.add(tagName);
     tagRules.push({schema, env, tagName, validators: boundValidators});
   }
+
   return {
     TaggedTemplateExpression(node) {
       for (const {schema, env, tagName, validators} of tagRules) {
@@ -86,7 +87,7 @@ function createRule(context, optionParser) {
   };
 }
 
-const rules = {
+export const rules = {
   'template-strings': {
     meta: {
       schema: {
@@ -445,6 +446,7 @@ const gqlProcessor = {
     return [`${internalTag}\`${escaped}\``];
   },
   postprocess: function(messages) {
+    console.log('postprocess', messages)
     // only report graphql-errors
     return flatten(messages).filter((message) => {
       return includes(keys(rules).map((key) => `graphql/${key}`), message.ruleId);
@@ -452,11 +454,11 @@ const gqlProcessor = {
   }
 }
 
-const processors = reduce(gqlFiles, (result, value) => {
+export const processors = reduce(gqlFiles, (result, value) => {
     return { ...result, [`.${value}`]: gqlProcessor };
 }, {})
 
-module.exports = {
-  rules,
+export default {
+  rules, 
   processors
-};
+}

--- a/test/__fixtures__/required-fields-invalid-array.graphql
+++ b/test/__fixtures__/required-fields-invalid-array.graphql
@@ -1,0 +1,1 @@
+query { stories { comments { text } } }

--- a/test/__fixtures__/required-fields-invalid-no-id.graphql
+++ b/test/__fixtures__/required-fields-invalid-no-id.graphql
@@ -1,0 +1,1 @@
+query { greetings { hello } }

--- a/test/__fixtures__/required-fields-valid-array.graphql
+++ b/test/__fixtures__/required-fields-valid-array.graphql
@@ -1,0 +1,1 @@
+query { stories { id comments { text } } }

--- a/test/__fixtures__/required-fields-valid-id.graphql
+++ b/test/__fixtures__/required-fields-valid-id.graphql
@@ -1,0 +1,1 @@
+query { greetings { id, hello, foo } }

--- a/test/__fixtures__/required-fields-valid-no-id.graphql
+++ b/test/__fixtures__/required-fields-valid-no-id.graphql
@@ -1,0 +1,1 @@
+query { allFilms { films { title } } }

--- a/test/makeProcessors.js
+++ b/test/makeProcessors.js
@@ -1,40 +1,88 @@
-import assert from 'assert';
-import {
-  includes,
-  keys,
-} from 'lodash';
+import assert from "assert";
+import { CLIEngine } from "eslint";
+import { includes, keys } from "lodash";
+import path from "path";
 
-import { processors } from '../src';
+import schemaJson from "./schema.json";
+import plugin, { processors } from "../src";
 
-describe('processors', () => {
-  it('should define processors', () => {
+function execute(file) {
+  const cli = new CLIEngine({
+    extensions: [".gql", ".graphql"],
+    baseConfig: {
+      rules: {
+        "graphql/required-fields": {
+          schemaJson,
+          env: "literal",
+          requiredFields: ["id"]
+        }
+      }
+    },
+    ignore: false,
+    useEslintrc: false
+  });
+  cli.addPlugin("eslint-plugin-graphql", plugin);
+  return cli.executeOnFiles([
+    path.join(__dirname, "__fixtures__", `${file}.graphql`)
+  ]);
+}
+
+describe("processors", () => {
+  it("should define processors", () => {
     const extensions = keys(processors);
 
-    assert(includes(extensions, '.gql'));
-    assert(includes(extensions, '.graphql'));
+    assert(includes(extensions, ".gql"));
+    assert(includes(extensions, ".graphql"));
   });
 
-  it('should escape backticks and prepend internalTag', () => {
-    const query = 'query { someValueWith` }'
-    const expected = 'ESLintPluginGraphQLFile`query { someValueWith\\` }`'
-    const preprocess = processors['.gql'].preprocess;
+  it("should escape backticks and prepend internalTag", () => {
+    const query = "query { someValueWith` }";
+    const expected = "ESLintPluginGraphQLFile`query { someValueWith\\` }`";
+    const preprocess = processors[".gql"].preprocess;
     const result = preprocess(query);
 
     assert.equal(result, expected);
   });
 
-  it('should filter only graphql/* rules ', () => {
+  it("should filter only graphql/* rules ", () => {
     const messages = [
-      { ruleId: 'no-undef' },
-      { ruleId: 'semi' },
-      { ruleId: 'graphql/randomString' },
-      { ruleId: 'graphql/template-strings' },
+      { ruleId: "no-undef" },
+      { ruleId: "semi" },
+      { ruleId: "graphql/randomString" },
+      { ruleId: "graphql/template-strings" }
     ];
-    const expected = { ruleId: 'graphql/template-strings' };
-    const postprocess = processors['.gql'].postprocess;
+    const expected = { ruleId: "graphql/template-strings" };
+    const postprocess = processors[".gql"].postprocess;
     const result = postprocess(messages);
 
     assert.equal(result.length, 1);
     assert.equal(result[0].ruleId, expected.ruleId);
+  });
+
+  describe("graphql/required-fields", () => {
+    describe("valid", () => {
+      [
+        "required-fields-valid-no-id",
+        "required-fields-valid-id",
+        "required-fields-valid-array"
+      ].forEach(filename => {
+        it(`does not warn on file ${filename}`, () => {
+          const results = execute(filename);
+          assert.equal(results.errorCount, 0);
+        });
+      });
+    });
+
+    describe.only("invalid", () => {
+      [
+        "required-fields-invalid-no-id",
+        "required-fields-invalid-array"
+      ].forEach(filename => {
+        it(`warns on file ${filename}`, () => {
+          const results = execute(filename);
+          assert.equal(results.errorCount, 1);
+        });
+      });
+    });
   });
 });

--- a/test/makeProcessors.js
+++ b/test/makeProcessors.js
@@ -1,22 +1,22 @@
-import assert from "assert";
-import { CLIEngine } from "eslint";
-import { includes, keys } from "lodash";
-import path from "path";
+import assert from 'assert';
+import { CLIEngine } from 'eslint';
+import { includes, keys } from 'lodash';
+import path from 'path';
 
-import schemaJson from "./schema.json";
-import plugin, { processors } from "../src";
+import schemaJson from './schema.json';
+import plugin, { processors } from '../src';
 
 function execute(file) {
   const cli = new CLIEngine({
-    extensions: [".gql", ".graphql"],
+    extensions: ['.gql', '.graphql'],
     baseConfig: {
       rules: {
-        "graphql/required-fields": [
-          "error",
+        'graphql/required-fields': [
+          'error',
           {
             schemaJson,
-            env: "literal",
-            requiredFields: ["id"]
+            env: 'literal',
+            requiredFields: ['id']
           }
         ]
       }
@@ -25,53 +25,53 @@ function execute(file) {
     useEslintrc: false,
     parserOptions: {
       ecmaVersion: 6,
-      sourceType: "module"
+      sourceType: 'module'
     }
   });
-  cli.addPlugin("eslint-plugin-graphql", plugin);
+  cli.addPlugin('eslint-plugin-graphql', plugin);
   return cli.executeOnFiles([
-    path.join(__dirname, "__fixtures__", `${file}.graphql`)
+    path.join(__dirname, '__fixtures__', `${file}.graphql`)
   ]);
 }
 
-describe("processors", () => {
-  it("should define processors", () => {
+describe('processors', () => {
+  it('should define processors', () => {
     const extensions = keys(processors);
 
-    assert(includes(extensions, ".gql"));
-    assert(includes(extensions, ".graphql"));
+    assert(includes(extensions, '.gql'));
+    assert(includes(extensions, '.graphql'));
   });
 
-  it("should escape backticks and prepend internalTag", () => {
-    const query = "query { someValueWith` }";
-    const expected = "ESLintPluginGraphQLFile`query { someValueWith\\` }`";
-    const preprocess = processors[".gql"].preprocess;
+  it('should escape backticks and prepend internalTag', () => {
+    const query = 'query { someValueWith` }';
+    const expected = 'ESLintPluginGraphQLFile`query { someValueWith\\` }`';
+    const preprocess = processors['.gql'].preprocess;
     const result = preprocess(query);
 
     assert.equal(result, expected);
   });
 
-  it("should filter only graphql/* rules ", () => {
+  it('should filter only graphql/* rules ', () => {
     const messages = [
-      { ruleId: "no-undef" },
-      { ruleId: "semi" },
-      { ruleId: "graphql/randomString" },
-      { ruleId: "graphql/template-strings" }
+      { ruleId: 'no-undef' },
+      { ruleId: 'semi' },
+      { ruleId: 'graphql/randomString' },
+      { ruleId: 'graphql/template-strings' }
     ];
-    const expected = { ruleId: "graphql/template-strings" };
-    const postprocess = processors[".gql"].postprocess;
+    const expected = { ruleId: 'graphql/template-strings' };
+    const postprocess = processors['.gql'].postprocess;
     const result = postprocess(messages);
 
     assert.equal(result.length, 1);
     assert.equal(result[0].ruleId, expected.ruleId);
   });
 
-  describe("graphql/required-fields", () => {
-    describe("valid", () => {
+  describe('graphql/required-fields', () => {
+    describe('valid', () => {
       [
-        "required-fields-valid-no-id",
-        "required-fields-valid-id",
-        "required-fields-valid-array"
+        'required-fields-valid-no-id',
+        'required-fields-valid-id',
+        'required-fields-valid-array'
       ].forEach(filename => {
         it(`does not warn on file ${filename}`, () => {
           const results = execute(filename);
@@ -80,10 +80,10 @@ describe("processors", () => {
       });
     });
 
-    describe.only("invalid", () => {
+    describe.only('invalid', () => {
       [
-        "required-fields-invalid-no-id",
-        "required-fields-invalid-array"
+        'required-fields-invalid-no-id',
+        'required-fields-invalid-array'
       ].forEach(filename => {
         it(`warns on file ${filename}`, () => {
           const results = execute(filename);

--- a/test/makeProcessors.js
+++ b/test/makeProcessors.js
@@ -80,7 +80,7 @@ describe('processors', () => {
       });
     });
 
-    describe.only('invalid', () => {
+    describe('invalid', () => {
       [
         'required-fields-invalid-no-id',
         'required-fields-invalid-array'

--- a/test/makeProcessors.js
+++ b/test/makeProcessors.js
@@ -11,15 +11,22 @@ function execute(file) {
     extensions: [".gql", ".graphql"],
     baseConfig: {
       rules: {
-        "graphql/required-fields": {
-          schemaJson,
-          env: "literal",
-          requiredFields: ["id"]
-        }
+        "graphql/required-fields": [
+          "error",
+          {
+            schemaJson,
+            env: "literal",
+            requiredFields: ["id"]
+          }
+        ]
       }
     },
     ignore: false,
-    useEslintrc: false
+    useEslintrc: false,
+    parserOptions: {
+      ecmaVersion: 6,
+      sourceType: "module"
+    }
   });
   cli.addPlugin("eslint-plugin-graphql", plugin);
   return cli.executeOnFiles([
@@ -81,6 +88,8 @@ describe("processors", () => {
         it(`warns on file ${filename}`, () => {
           const results = execute(filename);
           assert.equal(results.errorCount, 1);
+          const message = results.results[0].messages[0].message;
+          assert.ok(new RegExp("'id' field required").test(message));
         });
       });
     });

--- a/test/makeRule.js
+++ b/test/makeRule.js
@@ -946,7 +946,20 @@ const requiredFieldsTestCases = {
     invalid: values(namedOperationsValidatorCases).map(({fail: code, errors}) => ({options, parserOptions, code, errors})),
   });
 
-  // Validate the required-fields rule
+  // Validate the required-fields rule with env specified
+  options = [{
+    schemaJson,
+    env: 'apollo',
+    tagName: 'gql',
+    requiredFields: ['id'],
+  }];
+
+  ruleTester.run('testing required-fields rule', rules['required-fields'], {
+    valid: requiredFieldsTestCases.pass.map((code) => ({options, parserOptions, code})),
+    invalid: requiredFieldsTestCases.fail.map(({code, errors}) => ({options, parserOptions, code, errors})),
+  });
+
+  // Validate required-fields without optional env argument
   options = [{
     schemaJson,
     tagName: 'gql',


### PR DESCRIPTION
@jnwng :eyes: please 
Allows .graphql and .gql literal files to be linted with the required-fields rule. Resolves #74 

Note: Neglected to update the README when I removed a few broken rules from the `literal` env and just threw the update in here, since I was already at it.

TODO:

- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests pass
- [x] Update CHANGELOG.md with your change
- [x] If this was a change that affects the external API, update the README
