### PR TITLE
Fix Crash with InlineFragments and RequiredFields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Change log
 ### vNEXT
+- Fix required field crash error on inline fragments [Scott Peper](https://github.com/cspeper/)
 
 ### v1.5.0
 - Add new rule `no-deprecated-fields` in [Kristján Oddsson](https://github.com/koddsson/)[#92](https://github.com/apollographql/eslint-plugin-graphql/pull/93)

--- a/src/rules.js
+++ b/src/rules.js
@@ -33,7 +33,7 @@ export function RequiredFields(context, options) {
         }
         if (fieldAvaliableOnType || fieldAvaliableOnOfType) {
           const fieldWasRequested = !!node.selectionSet.selections.find(
-            n => (n.name.value === field || n.kind === 'FragmentSpread')
+            n => (n.kind === 'FragmentSpread' || n.kind === 'InlineFragment' || n.name.value === field)
           );
           if (!fieldWasRequested) {
             context.reportError(

--- a/test/__fixtures__/required-fields-inline-invalid-no-id.graphql
+++ b/test/__fixtures__/required-fields-inline-invalid-no-id.graphql
@@ -1,0 +1,7 @@
+mutation CreateStory($input: CreateStoryInput!) {
+  createStory(input: $input) {
+    ... on Story {
+      text
+    }
+  }
+}

--- a/test/makeProcessors.js
+++ b/test/makeProcessors.js
@@ -70,6 +70,7 @@ describe('processors', () => {
     describe('valid', () => {
       [
         'required-fields-valid-no-id',
+        'required-fields-inline-valid-no-id',
         'required-fields-valid-id',
         'required-fields-valid-array'
       ].forEach(filename => {

--- a/test/schema.graphql
+++ b/test/schema.graphql
@@ -5,10 +5,15 @@ schema {
 
 type RootMutation {
   createComment(input: CreateCommentInput): CreateCommentPayload
+  createStory(input: CreateStoryInput): Story
 }
 
 input CreateCommentInput {
   stuff: String
+}
+
+input CreateStoryInput {
+  text: String
 }
 
 type CreateCommentPayload {


### PR DESCRIPTION
This PR resolves issue of crashes when using `required-fields` and `InlineFragments`:
https://github.com/apollographql/eslint-plugin-graphql/issues/79
