### PR TITLE
Option to ignore fragment spreads

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -188,6 +188,9 @@ export const rules = {
                 type: 'string',
               },
             },
+            ignoreFragmentSpreads: {
+              type: 'boolean',
+            }
           },
           required: ['requiredFields'],
           ...schemaPropsExclusiveness,

--- a/src/rules.js
+++ b/src/rules.js
@@ -19,7 +19,7 @@ export function RequiredFields(context, options) {
       if (!def) {
         return;
       }
-      const { requiredFields } = options;
+      const { requiredFields, ignoreFragmentSpreads } = options;
       requiredFields.forEach(field => {
         const fieldAvaliableOnType = def.type && def.type._fields && def.type._fields[field];
 
@@ -33,7 +33,7 @@ export function RequiredFields(context, options) {
         }
         if (fieldAvaliableOnType || fieldAvaliableOnOfType) {
           const fieldWasRequested = !!node.selectionSet.selections.find(
-            n => (n.name.value === field || n.kind === 'FragmentSpread')
+            n => (n.name.value === field || (!ignoreFragmentSpreads && n.kind === 'FragmentSpread'))
           );
           if (!fieldWasRequested) {
             context.reportError(


### PR DESCRIPTION
I've not completed the checklist below yet; first wanted to check if you'd be happy to add this option? It allows you to have stronger guarantees that the requiredFields will definitely be present (and is backwards compatible because you opt into the functionality).

TODO:

- [ ] Make sure all of the significant new logic is covered by tests
- [ ] Rebase your changes on master so that they can be merged easily
- [ ] Make sure all tests pass
- [ ] Update CHANGELOG.md with your change
- [ ] If this was a change that affects the external API, update the README
