### PR TITLE
Fix error locations for .graphql files and tagged strings with leading newlines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Change log
 ### vNEXT
+- Fix error location information for literal .graphql files and strings with leading newlines in [#122](https://github.com/apollographql/eslint-plugin-graphql/pull/122) by [Dan Freeman](https://github.com/dfreeman)
 
 ### v2.1.0
 - Retrieves `.graphqlconfig` relative to the file being linted, which re-enables support for `vscode-eslint` using `.graphqlconfig` in [#108](https://github.com/apollographql/eslint-plugin-graphql/pull/108) by [Jon Wong][https://github.com/jnwng/]

--- a/src/index.js
+++ b/src/index.js
@@ -418,11 +418,11 @@ function locFrom(node, error) {
 
   let line;
   let column;
-  if (location.line === 1) {
+  if (location.line === 1 && node.tag.name !== internalTag) {
     line = node.loc.start.line;
-    column = node.loc.start.col + location.col;
+    column = node.tag.loc.end.column + location.column;
   } else {
-    line = node.loc.start.line + location.line;
+    line = node.loc.start.line + location.line - 1;
     column = location.column - 1;
   }
 
@@ -489,7 +489,7 @@ function replaceExpressions(node, context, env) {
     }
   });
 
-  return chunks.join('').trim();
+  return chunks.join('');
 }
 
 function strWithLen(len) {

--- a/test/__fixtures__/required-fields-invalid-no-id.graphql
+++ b/test/__fixtures__/required-fields-invalid-no-id.graphql
@@ -1,1 +1,5 @@
-query { greetings { hello } }
+query {
+  greetings {
+    hello
+  }
+}

--- a/test/makeProcessors.js
+++ b/test/makeProcessors.js
@@ -93,5 +93,35 @@ describe('processors', () => {
         });
       });
     });
+
+    describe('error line/column locations', () => {
+      it('populates correctly for a single-line document', () => {
+        const results = execute('required-fields-invalid-array');
+        assert.equal(results.errorCount, 1);
+        assert.deepEqual(results.results[0].messages[0], {
+          column: 9,
+          line: 1,
+          message: "'id' field required on 'stories'",
+          nodeType: 'TaggedTemplateExpression',
+          ruleId: 'graphql/required-fields',
+          severity: 2,
+          source: 'ESLintPluginGraphQLFile`query { stories { comments { text } } }'
+        });
+      });
+
+      it('populates correctly for a multi-line document', () => {
+        const results = execute('required-fields-invalid-no-id');
+        assert.equal(results.errorCount, 1);
+        assert.deepEqual(results.results[0].messages[0], {
+          column: 3,
+          line: 2,
+          message: "'id' field required on 'greetings'",
+          nodeType: 'TaggedTemplateExpression',
+          ruleId: 'graphql/required-fields',
+          severity: 2,
+          source: '  greetings {'
+        });
+      });
+    });
   });
 });

--- a/test/makeRule.js
+++ b/test/makeRule.js
@@ -73,10 +73,12 @@ const parserOptions = {
       {
         options,
         parserOptions,
-        code: 'const x = gql`{ nonExistentQuery }`',
+        code: 'const x = gql`\n  query {\n    nonExistentQuery\n  }\n`',
         errors: [{
           message: 'Cannot query field "nonExistentQuery" on type "Query".',
-          type: 'TaggedTemplateExpression'
+          type: 'TaggedTemplateExpression',
+          line: 3,
+          column: 5
         }]
       },
       {


### PR DESCRIPTION
Thanks for maintaining this plugin! I ran into some odd error locations when using it with raw `.graphql` files, and it looks like the ultimate culprit was an off-by-one bug 🙂 

- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests pass
- [x] Update CHANGELOG.md with your change
- [ ] ~If this was a change that affects the external API, update the README~

Prior to this change, the contents of tagged strings were having leading and trailing whitespace trimmed before being processed. This masked an off-by-one error in the location calculation for errors after the first line of a document, since the most common usage pattern has a single extra leading line before the actual content which offsets that:

```js
const query = gql`
  query ...
`;
```

This meant that standalone `.graphql` files had all their errors displayed on the wrong line (unless they opened with a single blank line as well), and tagged strings with multiple newlines at their start would also have issues. This patch removes the `.trim()` call and updates the `line`/`column` calculations to report the correct location.