### PR TITLE
Cache for parsing the schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change log
 ### vNEXT
 - Retrieves `.graphqlconfig` relative to the file being linted, which re-enables support for `vscode-eslint` using `.graphqlconfig` in [#108](https://github.com/apollographql/eslint-plugin-graphql/pull/108) by [Jon Wong][https://github.com/jnwng/]
+- Cache schema reading/parsing results each time a rule is created in [#137](https://github.com/apollographql/eslint-plugin-graphql/pull/137) by [Kristján Oddsson](https://github.com/koddsson)
 
 ### v2.0.0
 - Add support for `graphql-js@^0.12.0` and `graphql-js@^0.13.0` in [Jon Wong](https://github.com/jnwng/)[#119] (https://github.com/apollographql/eslint-plugin-graphql/pull/93)

--- a/src/index.js
+++ b/src/index.js
@@ -243,7 +243,13 @@ export const rules = {
   },
 };
 
+const schemaCache = {}
+
 function parseOptions(optionGroup, context) {
+  const cacheHit = schemaCache[JSON.stringify(optionGroup)]
+  if (cacheHit) {
+    return cacheHit
+  }
   const {
     schemaJson, // Schema via JSON object
     schemaJsonFilepath, // Or Schema via absolute filepath
@@ -322,7 +328,9 @@ function parseOptions(optionGroup, context) {
       return require(`graphql/validation/rules/${name}`)[name];
     }
   });
-  return {schema, env, tagName, validators};
+  const results = {schema, env, tagName, validators};
+  schemaCache[JSON.stringify(optionGroup)] = results;
+  return results;
 }
 
 function initSchema(json) {

--- a/src/index.js
+++ b/src/index.js
@@ -243,12 +243,12 @@ export const rules = {
   },
 };
 
-const schemaCache = {}
+const schemaCache = {};
 
 function parseOptions(optionGroup, context) {
-  const cacheHit = schemaCache[JSON.stringify(optionGroup)]
+  const cacheHit = schemaCache[JSON.stringify(optionGroup)];
   if (cacheHit) {
-    return cacheHit
+    return cacheHit;
   }
   const {
     schemaJson, // Schema via JSON object


### PR DESCRIPTION
👋 Hey hey!

When working with large GraphQL schemas (like GitHubs v4 API schema) we've noticed that eslint could run a bit slower. We narrowed it down to `eslint-plugin-graphql` adding ~500ms per file to the run time of `eslint`.

By adding a simple cache object for the schema results of `parseOptions` we can bring that time down pretty signifigantly.

Here's a example eslint run in one of our projects at GitHub:

Before this patch:
```
⚡ time TIMING=1 ./node_modules/.bin/eslint .
Rule                            | Time (ms) | Relative
:-------------------------------|----------:|--------:
prettier/prettier               |  5956.319 |    57.1%
graphql/no-deprecated-fields    |  1427.804 |    13.7%
import/namespace                |   810.107 |     7.8%
no-unused-vars                  |   274.724 |     2.6%
import/no-deprecated            |   148.324 |     1.4%
react/no-direct-mutation-state  |   124.988 |     1.2%
react/no-unused-prop-types      |   117.736 |     1.1%
react/prefer-stateless-function |   115.713 |     1.1%
import/named                    |    86.341 |     0.8%
react/no-deprecated             |    77.588 |     0.7%
TIMING=1 ./node_modules/.bin/eslint .  174.30s user 4.23s system 97% cpu 3:02.83 total
```

After this patch:
```
⚡ time TIMING=1 ./node_modules/.bin/eslint .
cache miss
Rule                                | Time (ms) | Relative
:-----------------------------------|----------:|--------:
prettier/prettier                   |  2788.298 |    65.9%
import/namespace                    |   415.556 |     9.8%
no-unused-vars                      |    68.644 |     1.6%
import/no-deprecated                |    60.269 |     1.4%
react/no-unused-prop-types          |    52.729 |     1.2%
graphql/no-deprecated-fields        |    52.299 |     1.2%
import/named                        |    48.913 |     1.2%
react/no-direct-mutation-state      |    45.669 |     1.1%
react/void-dom-elements-no-children |    45.446 |     1.1%
react/prefer-stateless-function     |    38.467 |     0.9%
TIMING=1 ./node_modules/.bin/eslint .  10.07s user 0.43s system 125% cpu 8.356 total
```

(There seems to be some `prettier/prettier` weirdness going on here as well)

I wasn't quite sure on how to test this but am open for suggestions if you've got any.

TODO:

- [ ] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests pass
- [x] Update CHANGELOG.md with your change
- [ ] If this was a change that affects the external API, update the README

**Pull Request Labels**

<!--
While not necessary, you can help organize our pull request by labeling this pull request when you open it.  To add a label automatically, simply [x] mark the appropriate box below:
-->

- [ ] feature
- [ ] blocking
- [ ] docs

<!--
You are also able to add labels by placing /label on a new line
followed by the label you would like to add. ex: /label discussion
-->

/label performance
