### PR TITLE
Stop assuming fragments contain required field

### DIFF
--- a/src/rules.js
+++ b/src/rules.js
@@ -18,9 +18,10 @@ function getFieldWasRequestedOnNode(node, field, recursing = false) {
     if (n.kind === 'InlineFragment' && !recursing) {
       return getFieldWasRequestedOnNode(n, field, true);
     }
+    // We don't know if the field was requested within the fragment, so default to assuming it's
+    // not, to be safe. This requires that the field be requested outside the fragment.
     if (n.kind === 'FragmentSpread') {
-      // We don't know if the field was requested in this case, so default to not erroring.
-      return true;
+      return false;
     }
     return n.name.value === field;
   });

--- a/test/makeRule.js
+++ b/test/makeRule.js
@@ -885,6 +885,15 @@ const requiredFieldsTestCases = {
         },
       ],
     },
+    {
+      code: 'const x = gql`query { greetings { hello ...GreetingsFragment} }`',
+      errors: [
+        {
+          message: `'id' field required on 'greetings'`,
+          type: 'TaggedTemplateExpression',
+        },
+      ],
+    },
   ],
 };
 


### PR DESCRIPTION
This is very similar to https://github.com/apollographql/eslint-plugin-graphql/pull/115, however it makes the behaviour default instead of opt-in. I think this is sensible, as the included test case shows - previously it would have passed. This will introduce new eslint errors to codebases on nodes where people had omitted required fields _and_ had a fragment spread.