### PR TITLE
replacing ProvidedNonNullArguments with ProvidedRequiredArguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Change log
 ### vNEXT
+- Fix breaking change in `graphql@^14.0.0` that renamed `ProvidedNonNullArguments` to `ProvidedRequiredArguments` [#180](https://github.com/apollographql/eslint-plugin-graphql/pull/180)
 
 ### v2.1.1
 - Fix support for InlineFragments with the `required-fields` rule in [#140](https://github.com/apollographql/eslint-plugin-graphql/pull/140/files) by [Steve Hollaar](https://github.com/stevehollaar)

--- a/src/index.js
+++ b/src/index.js
@@ -38,7 +38,7 @@ const envGraphQLValidatorNames = {
     'KnownFragmentNames',
     'NoUndefinedVariables',
     'NoUnusedFragments',
-    'ProvidedNonNullArguments',
+    'ProvidedRequiredArguments',
     'ScalarLeafs',
   ),
   literal: without(allGraphQLValidatorNames,

--- a/test/makeRule.js
+++ b/test/makeRule.js
@@ -678,7 +678,7 @@ const validatorCases = {
   'KnownArgumentNames': {
     pass: 'const x = gql`{ sum(a: 1, b: 2) }`',
     fail: 'const x = gql`{ sum(c: 1, d: 2) }`',
-    alsoBreaks: ['ProvidedNonNullArguments'],
+    alsoBreaks: ['ProvidedRequiredArguments'],
     errors: [{
       message: 'Unknown argument "c" on field "sum" of type "Query". Did you mean "a" or "b"?',
       type: 'TaggedTemplateExpression',
@@ -767,7 +767,7 @@ const validatorCases = {
       type: 'TaggedTemplateExpression',
     }],
   },
-  'ProvidedNonNullArguments': {
+  'ProvidedRequiredArguments': {
     pass: 'const x = gql`{ sum(a: 1, b: 2) }`',
     fail: 'const x = gql`{ sum(a: 1) }`',
     errors: [{
@@ -786,7 +786,7 @@ const validatorCases = {
   'UniqueArgumentNames': {
     pass: 'const x = gql`{ sum(a: 1, b: 2) }`',
     fail: 'const x = gql`{ sum(a: 1, a: 2) }`',
-    alsoBreaks: ['ProvidedNonNullArguments'],
+    alsoBreaks: ['ProvidedRequiredArguments'],
     errors: [{
       message: 'There can be only one argument named "a".',
       type: 'TaggedTemplateExpression',


### PR DESCRIPTION
As per https://github.com/apollographql/eslint-plugin-graphql/pull/170 this was a breaking change when upgrading to `graphql@^14.0.0`.

<!--
  Thanks for filing a pull request on eslint-plugin-graphql!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

- [ ] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [ ] Make sure all tests pass
- [x] Update CHANGELOG.md with your change
- [ ] If this was a change that affects the external API, update the README

**Pull Request Labels**

<!--
While not necessary, you can help organize our pull request by labeling this pull request when you open it.  To add a label automatically, simply [x] mark the appropriate box below:
-->

- [ ] feature
- [ ] blocking
- [ ] docs

<!--
You are also able to add labels by placing /label on a new line
followed by the label you would like to add. ex: /label discussion
-->
