### PR TITLE
fixing broken test assertions from eslint 5.0.0 upgrade

### DIFF
--- a/test/makeProcessors.js
+++ b/test/makeProcessors.js
@@ -105,7 +105,6 @@ describe('processors', () => {
           nodeType: 'TaggedTemplateExpression',
           ruleId: 'graphql/required-fields',
           severity: 2,
-          source: 'ESLintPluginGraphQLFile`query { stories { comments { text } } }'
         });
       });
 
@@ -119,7 +118,6 @@ describe('processors', () => {
           nodeType: 'TaggedTemplateExpression',
           ruleId: 'graphql/required-fields',
           severity: 2,
-          source: '  greetings {'
         });
       });
     });


### PR DESCRIPTION
removing `source` from message assertions as it [has been removed](https://github.com/eslint/eslint/blob/master/docs/user-guide/migrating-to-5.0.0.md#source-property) in eslint 5.0.0 (in https://github.com/eslint/eslint/pull/10012)

<!--
  Thanks for filing a pull request on eslint-plugin-graphql!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

- [ ] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [ ] Make sure all tests pass
- [ ] Update CHANGELOG.md with your change
- [ ] If this was a change that affects the external API, update the README

**Pull Request Labels**

<!--
While not necessary, you can help organize our pull request by labeling this pull request when you open it.  To add a label automatically, simply [x] mark the appropriate box below:
-->

- [ ] feature
- [ ] blocking
- [ ] docs

<!--
You are also able to add labels by placing /label on a new line
followed by the label you would like to add. ex: /label discussion
-->
