### PR TITLE
adds example on how to name the tag when using multiple schemas

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,11 +294,11 @@ module.exports = {
   rules: {
     "graphql/template-strings": ['error', {
       env: 'apollo',
-      tagName: 'FirstGQL',
+      tagName: 'apolloGQL',
       projectName: 'FirstGQLProject'
     }, {
       env: 'relay',
-      tagName: 'SecondGQL',
+      tagName: 'relayGQL',
       projectName: 'SecondGQLProject'
     }]
   },
@@ -307,6 +307,8 @@ module.exports = {
   ]
 }
 ```
+
+So then for example import and use your graphql-tag as `apolloGQL`: `import apolloGQL from 'graphql-tag';`
 
 ### Selecting Validation Rules
 


### PR DESCRIPTION
this should prevent questions like this one: https://github.com/apollographql/eslint-plugin-graphql/issues/84

which I had to find for myself.

