### PR TITLE
Always guard against undefined type in fieldAvailableOnType

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### vNEXT
 
+- Fix an issue that caused `graphql/required-fields` to throw on non-existent field references. [PR #231](https://github.com/apollographql/eslint-plugin-graphql/pull/231) by [Vitor Balocco](https://github.com/vitorbal)
+
 ### v3.0.3
 
 - chore: Update dependency `graphql-tools` to `v4.0.4`. [PR #210](https://github.com/apollographql/eslint-plugin-graphql/pull/210)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1868,8 +1868,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -1890,14 +1889,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -1912,20 +1909,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2042,8 +2036,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2055,7 +2048,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2070,7 +2062,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2078,14 +2069,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -2104,7 +2093,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2185,8 +2173,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2198,7 +2185,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2284,8 +2270,7 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2321,7 +2306,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2341,7 +2325,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2385,14 +2368,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -2432,7 +2413,6 @@
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
       "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
       "dev": true,
-      "optional": true,
       "requires": {
         "is-glob": "^2.0.0"
       }
@@ -2687,8 +2667,7 @@
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
       "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "is-ci": {
       "version": "2.0.0",
@@ -2727,8 +2706,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
       "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "is-finite": {
       "version": "1.0.2",
@@ -2750,7 +2728,6 @@
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
       "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
       "dev": true,
-      "optional": true,
       "requires": {
         "is-extglob": "^1.0.0"
       }
@@ -2857,7 +2834,6 @@
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
       "dev": true,
-      "optional": true,
       "requires": {
         "is-buffer": "^1.1.5"
       }
@@ -3064,7 +3040,6 @@
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
       "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
       "dev": true,
-      "optional": true,
       "requires": {
         "remove-trailing-separator": "^1.0.1"
       }
@@ -3377,15 +3352,13 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
       "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "repeat-element": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
       "integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "repeat-string": {
       "version": "1.6.1",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "author": "Sashko Stubailo",
   "main": "lib/index.js",
   "scripts": {
-    "test": "tav --ci && mocha test/index.js",
+    "test": "tav",
     "prepublish": "babel ./src --ignore test --out-dir ./lib",
     "pretest": "node test/updateSchemaJson.js",
     "tav": "tav",

--- a/src/customGraphQLValidationRules.js
+++ b/src/customGraphQLValidationRules.js
@@ -19,8 +19,12 @@ function getFieldWasRequestedOnNode(node, field) {
 }
 
 function fieldAvailableOnType(type, field) {
+  if (!type) {
+    return false;
+  }
+
   return (
-    (type && type._fields && type._fields[field]) ||
+    (type._fields && type._fields[field]) ||
     (type.ofType && fieldAvailableOnType(type.ofType, field))
   );
 }

--- a/test/validationRules/built-in.js
+++ b/test/validationRules/built-in.js
@@ -72,7 +72,7 @@ const validatorCases = {
       "const x = gql`fragment FilmFragment on Floof { title } { allFilms { films { ...FilmFragment } } }`",
     errors: [
       {
-        message: 'Unknown type "Floof".',
+        message: /Unknown type "Floof"/,
         type: "TaggedTemplateExpression"
       }
     ]
@@ -162,7 +162,7 @@ const validatorCases = {
     errors: [
       {
         message:
-          'Field "sum" argument "b" of type "Int!" is required but not provided.',
+          /Field "sum" argument "b" of type "Int!" is required/,
         type: "TaggedTemplateExpression"
       }
     ]

--- a/test/validationRules/required-fields.js
+++ b/test/validationRules/required-fields.js
@@ -11,6 +11,7 @@ const requiredFieldsTestCases = {
     "const x = gql`query { greetings { id, hello, foo } }`",
     "const x = gql`query { greetings { id ... on Greetings { hello } } }`",
     "const x = gql`fragment Name on Greetings { id hello }`",
+    "const x = gql`fragment Foo on FooBar { id, hello, foo }`",
     "const x = gql`fragment Id on Node { id ... on NodeA { fieldA } }`",
     "const x = gql`query { nodes { id ... on NodeA { fieldA } } }`",
   ],


### PR DESCRIPTION
Previously, only the first half of the check inside `fieldAvailableOnType` guarded against `type` being `undefined`. This meant that the function would throw an error.

To fix this, and o prevent it from accidentally happening again if we ever add another check to this logic, I moved the check for `!type` up into it's own guard, with an early return.

This change makes the required-fields rule more resilient (which uses this `fieldAvailableOnType` function internally).

Without this change, I see errors when trying to run `eslint-plugin-graphql` against my project:
```
Cannot read property 'ofType' of undefined
TypeError: Cannot read property 'ofType' of undefined
    at fieldAvailableOnType (/Code/vitorbal/node_modules/eslint-plugin-graphql/lib/customGraphQLValidationRules.js:33:62)
    at /Code/vitorbal/node_modules/eslint-plugin-graphql/lib/customGraphQLValidationRules.js:49:13
    at Array.forEach (<anonymous>)
    at Object.FragmentDefinition (/Code/vitorbal/node_modules/eslint-plugin-graphql/lib/customGraphQLValidationRules.js:42:22)
    at Object.enter (/Code/vitorbal/node_modules/graphql/language/visitor.js:332:29)
    at Object.enter (/Code/vitorbal/node_modules/graphql/language/visitor.js:383:25)
    at visit (/Code/vitorbal/node_modules/graphql/language/visitor.js:250:26)
    at validate (/Code/vitorbal/node_modules/graphql/validation/validate.js:63:22)
    at handleTemplateTag (/Code/vitorbal/node_modules/eslint-plugin-graphql/lib/createRule.js:133:57)
    at TaggedTemplateExpression (/Code/vitorbal/node_modules/eslint-plugin-graphql/lib/createRule.js:226:20)
```

<!--
  Thanks for filing a pull request on eslint-plugin-graphql!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests pass
- [x] Update CHANGELOG.md with your change
- [x] If this was a change that affects the external API, update the README

