### PR TITLE
Fixing issues with tests failing using `graphql-js@14.3.0`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2430,9 +2430,9 @@
       "dev": true
     },
     "graphql": {
-      "version": "14.1.1",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-14.1.1.tgz",
-      "integrity": "sha512-C5zDzLqvfPAgTtP8AUPIt9keDabrdRAqSWjj2OPRKrKxI9Fb65I36s1uCs1UUBFnSWTdO7hyHi7z1ZbwKMKF6Q==",
+      "version": "14.3.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-14.3.0.tgz",
+      "integrity": "sha512-MdfI4v7kSNC3NhB7cF8KNijDsifuWO2XOtzpyququqaclO8wVuChYv+KogexDwgP5sp7nFI9Z6N4QHgoLkfjrg==",
       "dev": true,
       "requires": {
         "iterall": "^1.2.2"

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "babel-preset-es2015": "6.24.1",
     "babel-preset-stage-0": "6.24.1",
     "eslint": "5.15.1",
-    "graphql": "14.1.1",
+    "graphql": "^14.3.0",
     "graphql-tools": "4.0.4",
     "mocha": "5.2.0",
     "prettier": "^1.18.2",

--- a/test/validationRules/built-in.js
+++ b/test/validationRules/built-in.js
@@ -72,7 +72,7 @@ const validatorCases = {
       "const x = gql`fragment FilmFragment on Floof { title } { allFilms { films { ...FilmFragment } } }`",
     errors: [
       {
-        message: 'Unknown type "Floof".',
+        message: new RegExp('Unknown type "Floof".'),
         type: "TaggedTemplateExpression"
       }
     ]
@@ -161,8 +161,9 @@ const validatorCases = {
     fail: "const x = gql`{ sum(a: 1) }`",
     errors: [
       {
-        message:
-          'Field "sum" argument "b" of type "Int!" is required but not provided.',
+        message: new RegExp(
+          'Field "sum" argument "b" of type "Int!" is required'
+        ),
         type: "TaggedTemplateExpression"
       }
     ]


### PR DESCRIPTION
Due to strict string matches between expected error messages and the error messages output by `graphql-js`, these tests were failing. Fortunately, `eslint#RuleTester` will test regular expressions if they're provided, so here I'm boiling down the tests to make sure they work properly across different versions of `graphql-js`

Holistically, I think it's a little difficult to continue to support so many different version of `graphql-js`. I think when `graphql@15.x` comes around, we may need to consider matching majors or splitting out tests based on what version of `graphql-js` is installed.

<!--
  Thanks for filing a pull request on eslint-plugin-graphql!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

- ~[ ] Make sure all of the significant new logic is covered by tests~
- ~[ ] Rebase your changes on master so that they can be merged easily~
- [ ] Make sure all tests pass
- [ ] Update CHANGELOG.md with your change
- [ ] If this was a change that affects the external API, update the README

