### PR TITLE
Always guard against undefined type in fieldAvailableOnType

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### vNEXT
 
+- Fix an issue that caused `graphql/required-fields` to throw on non-existent field references. [PR #231](https://github.com/apollographql/eslint-plugin-graphql/pull/231) by [Vitor Balocco](https://github.com/vitorbal)
+
 ### v3.0.3
 
 - chore: Update dependency `graphql-tools` to `v4.0.4`. [PR #210](https://github.com/apollographql/eslint-plugin-graphql/pull/210)

--- a/src/customGraphQLValidationRules.js
+++ b/src/customGraphQLValidationRules.js
@@ -19,8 +19,12 @@ function getFieldWasRequestedOnNode(node, field) {
 }
 
 function fieldAvailableOnType(type, field) {
+  if (!type) {
+    return false;
+  }
+
   return (
-    (type && type._fields && type._fields[field]) ||
+    (type._fields && type._fields[field]) ||
     (type.ofType && fieldAvailableOnType(type.ofType, field))
   );
 }

--- a/test/validationRules/required-fields.js
+++ b/test/validationRules/required-fields.js
@@ -11,6 +11,7 @@ const requiredFieldsTestCases = {
     "const x = gql`query { greetings { id, hello, foo } }`",
     "const x = gql`query { greetings { id ... on Greetings { hello } } }`",
     "const x = gql`fragment Name on Greetings { id hello }`",
+    "const x = gql`fragment Foo on FooBar { id, hello, foo }`",
     "const x = gql`fragment Id on Node { id ... on NodeA { fieldA } }`",
     "const x = gql`query { nodes { id ... on NodeA { fieldA } } }`",
   ],


### PR DESCRIPTION
Previously, only the first half of the check inside `fieldAvailableOnType` guarded against `type` being `undefined`. This meant that the function would throw an error.

To fix this, and o prevent it from accidentally happening again if we ever add another check to this logic, I moved the check for `!type` up into it's own guard, with an early return.

This change makes the required-fields rule more resilient (which uses this `fieldAvailableOnType` function internally).

Without this change, I see errors when trying to run `eslint-plugin-graphql` against my project:
```
Cannot read property 'ofType' of undefined
TypeError: Cannot read property 'ofType' of undefined
    at fieldAvailableOnType (/Code/vitorbal/node_modules/eslint-plugin-graphql/lib/customGraphQLValidationRules.js:33:62)
    at /Code/vitorbal/node_modules/eslint-plugin-graphql/lib/customGraphQLValidationRules.js:49:13
    at Array.forEach (<anonymous>)
    at Object.FragmentDefinition (/Code/vitorbal/node_modules/eslint-plugin-graphql/lib/customGraphQLValidationRules.js:42:22)
    at Object.enter (/Code/vitorbal/node_modules/graphql/language/visitor.js:332:29)
    at Object.enter (/Code/vitorbal/node_modules/graphql/language/visitor.js:383:25)
    at visit (/Code/vitorbal/node_modules/graphql/language/visitor.js:250:26)
    at validate (/Code/vitorbal/node_modules/graphql/validation/validate.js:63:22)
    at handleTemplateTag (/Code/vitorbal/node_modules/eslint-plugin-graphql/lib/createRule.js:133:57)
    at TaggedTemplateExpression (/Code/vitorbal/node_modules/eslint-plugin-graphql/lib/createRule.js:226:20)
```

<!--
  Thanks for filing a pull request on eslint-plugin-graphql!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests pass
- [x] Update CHANGELOG.md with your change
- [x] If this was a change that affects the external API, update the README

