### PR TITLE
Improve identity template literal tag docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### vNEXT
 
+- Improve identity template literal tag docs. [PR #254](https://github.com/apollographql/eslint-plugin-graphql/pull/254) by [Jayden Seric](https://github.com/jaydenseric).
+
 ### v3.1.0
 
 - Fix an issue that caused `graphql/required-fields` to throw on non-existent field references. [PR #231](https://github.com/apollographql/eslint-plugin-graphql/pull/231) by [Vitor Balocco](https://github.com/vitorbal)

--- a/README.md
+++ b/README.md
@@ -56,28 +56,21 @@ There's an example on how to use a `.graphqlconfig` file further down.
 
 ### Identity template literal tag
 
-This plugin relies on GraphQL queries being prefixed with a special tag. In Relay and Apollo, this is always done, but other clients often take query strings without a tag. In this case, you can define an identity tag that doesn't do anything except for tell the linter this is a GraphQL query:
+This plugin relies on GraphQL queries being prefixed with a special tag. In Relay and Apollo this is done often, but some other clients take query strings without a tag. In this case, [`fake-tag`](https://npm.im/fake-tag) can be used to define an identity tag that doesn't do anything except for tell the linter this is a GraphQL query:
 
 ```js
-global.gql = (literals, ...substitutions) => {
-    let result = "";
+import gql from "fake-tag";
 
-    // run the loop only for the substitution count
-    for (let i = 0; i < substitutions.length; i++) {
-        result += literals[i];
-        result += substitutions[i];
+const QUERY_VIEWER_NAME = gql`
+  query ViewerName {
+    viewer {
+      name
     }
-
-    // add the last literal
-    result += literals[literals.length - 1];
-
-    return result;
-}
+  }
+`;
 ```
 
-Code snippet taken from:  <https://leanpub.com/understandinges6/read#leanpub-auto-multiline-strings>
-
-Note: The linter rule could be extended to identify calls to various specific APIs to eliminate the need for a template literal tag, but this might just make the implementation a lot more complex for little benefit.
+Fake tags won’t be necessary [once `/* GraphQL */` comment tags are supported](https://github.com/apollographql/eslint-plugin-graphql/issues/224).
 
 ### GraphQL literal files
 


### PR DESCRIPTION
This PR improves the identity template literal tag docs:

- Tweaked the text from saying tags are “always” used in Apollo projects to “often”, as there are situations  where tags are not necessary like when making server side queries via `node-fetch` that come up in real world projects.
- Replaced the manual copy paste fake tag code with the suggestion to use [`fake-tag`](https://npm.im/fake-tag). This utility is easy to install and use and has tests covering Interpolations and escapes. It has been reasonably battle tested.
- Mentioned the `/* GraphQL */` comment tag enhancement issue (https://github.com/apollographql/eslint-plugin-graphql/issues/224).

See earlier discussion: https://github.com/apollographql/eslint-plugin-graphql/issues/224#issuecomment-486508146

TODO:

- [ ] Make sure all of the significant new logic is covered by tests
- [ ] Rebase your changes on master so that they can be merged easily
- [ ] Make sure all tests pass
- [x] Update CHANGELOG.md with your change
- [ ] If this was a change that affects the external API, update the README

