### PR TITLE
fix: support character escape sequences in template literal

### DIFF
--- a/src/createRule.js
+++ b/src/createRule.js
@@ -11,7 +11,7 @@ function replaceExpressions(node, context, env) {
   const chunks = [];
 
   node.quasis.forEach((element, i) => {
-    const chunk = element.value.cooked;
+    const chunk = element.value.raw;
     const value = node.expressions[i];
 
     chunks.push(chunk);


### PR DESCRIPTION
Use the `raw` value of the template literal instead of the `cooked` version.

i don't know if `cooked` was used intentionally, but tests still pass.

Motivation:

Gatsby uses `eslint-plugin-graphql`, which breaks when strings with character escape sequences are used in a query, e.g.:

```js
export const query = graphql`
{
  allFile(filter: {base: {regex: "/\\w+\\.PNG$/i"}}) {
    nodes { base }
  }
}
`
```

will throw "Syntax Error: Invalid character escape sequence"

if this makes sense i'll add a test for it - please advise where this should go.

---

TODO:

- [ ] Make sure all of the significant new logic is covered by tests
- [ ] Rebase your changes on master so that they can be merged easily
- [ ] Make sure all tests pass
- [ ] Update CHANGELOG.md with your change
- [ ] If this was a change that affects the external API, update the README

