### PR TITLE
Handle spread fragments for the required fields

### DIFF
--- a/src/customGraphQLValidationRules.js
+++ b/src/customGraphQLValidationRules.js
@@ -18,6 +18,12 @@ function getFieldWasRequestedOnNode(node, field) {
   });
 }
 
+function getNodeHasSpreadFragment(node) {
+  return node.selectionSet.selections.some(n => {
+    return n.kind === "FragmentSpread"
+  });
+}
+
 function fieldAvailableOnType(type, field) {
   if (!type) {
     return false;
@@ -38,6 +44,12 @@ export function RequiredFields(context, options) {
         const type = context.getType();
 
         if (fieldAvailableOnType(type, field)) {
+          // If there is a spread fragment, that spread fragment will already be checked for every field.
+          const nodeHasSpreadFragment = getNodeHasSpreadFragment(node);
+          if (nodeHasSpreadFragment) {
+            return
+          }
+
           const fieldWasRequested = getFieldWasRequestedOnNode(node, field);
           if (!fieldWasRequested) {
             context.reportError(
@@ -58,6 +70,12 @@ export function RequiredFields(context, options) {
         const type = context.getType();
 
         if (fieldAvailableOnType(type, field)) {
+          // If there is a spread fragment, that spread fragment will already be checked for every field.
+          const nodeHasSpreadFragment = getNodeHasSpreadFragment(node);
+          if (nodeHasSpreadFragment) {
+            return
+          }
+
           // First, check the selection set on this inline fragment
           if (node.selectionSet && getFieldWasRequestedOnNode(node, field)) {
             return true;
@@ -118,6 +136,12 @@ export function RequiredFields(context, options) {
 
       requiredFields.forEach(field => {
         if (fieldAvailableOnType(def.type, field)) {
+          // If there is a spread fragment, that spread fragment will already be checked for every field.
+          const nodeHasSpreadFragment = getNodeHasSpreadFragment(node);
+          if (nodeHasSpreadFragment) {
+            return
+          }
+
           const fieldWasRequested = getFieldWasRequestedOnNode(node, field);
           if (!fieldWasRequested) {
             context.reportError(

--- a/test/validationRules/required-fields.js
+++ b/test/validationRules/required-fields.js
@@ -18,6 +18,7 @@ const requiredFieldsTestCases = {
     "const x = gql`fragment Foo on FooBar { id, hello, foo }`",
     "const x = gql`fragment Id on Node { id ... on NodeA { fieldA } }`",
     "const x = gql`query { nodes { id ... on NodeA { fieldA } } }`",
+    "const x = gql`query { greetings { hello ...GreetingsFragment} }`"
   ],
   fail: [
     {
@@ -47,15 +48,6 @@ const requiredFieldsTestCases = {
           type: "TaggedTemplateExpression"
         }
       ]
-    },
-    {
-      code: 'const x = gql`query { greetings { hello ...GreetingsFragment} }`',
-      errors: [
-        {
-          message: `'id' field required on 'greetings'`,
-          type: 'TaggedTemplateExpression',
-        },
-      ],
     },
     {
       code: 'const x = gql`fragment Name on Greetings { hello }`',


### PR DESCRIPTION
Fix #248 

The current `required-fields` rule only checks that the required fields exist on the top level fragment or query. However, if someone is using spread fragments, this doesn't recursively check all fragments. 

The proposed solution in this PR only throws if the fragment or query has no spread fragment AND is missing the required field(s). This should work because at some point, the top-level spread fragment will be checked through the lint rule. As long as the top-level fragment has all required fields, all other fragments and queries that reference it will be covered as well.

First time contributor here, let me know if there are some explicit reasons not to include this. I tested it on my company's private repo and it worked as expected (and uncovered a few places an id was missing). 

TODO:

- [ ] Make sure all of the significant new logic is covered by tests
- [ ] Rebase your changes on master so that they can be merged easily
- [ ] Make sure all tests pass
- [ ] Update CHANGELOG.md with your change
- [ ] If this was a change that affects the external API, update the README

